### PR TITLE
Fixed brightness 0

### DIFF
--- a/ha-scenes.yaml
+++ b/ha-scenes.yaml
@@ -643,7 +643,7 @@ variables:
     {% endif %}
   brightness_value: |-
     {% if use_scene_brightness %}
-      {{ scenes[scene_name].b*100 }}
+      {{ (scenes[scene_name].b*100)|round(0, 'ceil') }}
     {% elif brightness %}
       {{ brightness }}
     {% else %}


### PR DESCRIPTION
In rare cases with the Nightlight scene it turns of my lights, after investigation I found that it was caused by the brightness in the scene.

Before:
```
0.004*100 -> 0.4 // This will send brightness 0% to the lights
```

After:
```
(0.004*100)|round(0, 'ceil') -> 1
```